### PR TITLE
fix sendQuery, refs https://github.com/mashingan/anonimongo/issues/6 for srv queries

### DIFF
--- a/src/dnsclient.nim
+++ b/src/dnsclient.nim
@@ -36,9 +36,13 @@ proc sendQuery*(c: DNSClient, query: string, kind: QKind = A, timeout = 500): Re
   buf.setPosition(0)
 
   var data = newStringOfCap(bufLen)
-  discard buf.readData(addr data, bufLen)
-
-  c.socket.sendTo(c.server, c.port, addr data, bufLen)
+  data.setLen 1
+    # ugly hack, nim should provide a way to get address of 1st element of a string
+    # with non-zero capacity (ie underlying c object not nil) and with 0 elements
+  data[0] = 'x'
+  let n = buf.readData(data[0].addr, bufLen)
+  doAssert n == bufLen
+  c.socket.sendTo(c.server, c.port, data[0].addr, bufLen)
 
   bufLen = 1024
   var


### PR DESCRIPTION
fixes the issue I was having in https://github.com/mashingan/anonimongo/issues/6#issuecomment-672148876

/cc @ba0f3 @mashingan

## note
there seems to be another bug (nim stdlib bug?) unrelated to this PR which is:
```nim
echo bufLen # 61
discard buf.readData(data.addr, bufLen)
echo bufLen # 8027506285661089891
```
