### PR TITLE
Fix: TXTRecord length field to unsigned

### DIFF
--- a/src/dnsclientpkg/records/txt.nim
+++ b/src/dnsclientpkg/records/txt.nim
@@ -1,9 +1,9 @@
 type TXTRecord* = ref object of ResourceRecord
-    length*: int8
+    length*: uint8
     data*: string
 
 method toString*(r: TXTRecord): string = r.data
 
 method parse*(r: TXTRecord, data: StringStream) =
-    r.length = data.readInt8()
-    r.data = data.readStr(r.length)
+    r.length = data.readUint8()
+    r.data = data.readStr(r.length.int)


### PR DESCRIPTION
Minor fix in the TXT parser.

I believe the TXT length field should be an unsigned 8-bit value, as specified in section 6.1 in https://www.ietf.org/rfc/rfc6763.txt.

Valid lengths are 0 - 255.
As it stands, any value larger than 127 would overflow and result in a `value out of range [RangeError]` exception.

Thanks! :)