### PR TITLE
Checked exceptions

### DIFF
--- a/src/dnsclientpkg/records/soa.nim
+++ b/src/dnsclientpkg/records/soa.nim
@@ -7,7 +7,7 @@ type SOARecord* = ref object of ResourceRecord
   expire*: int32
   minimum*: uint32
 
-method toString*(r: SOARecord): string = "$# $# $# $# $# $# $#" % [r.mname, r.rname, $r.serial, $r.refresh, $r.retry, $r.expire, $r.minimum]
+method toString*(r: SOARecord): string = [r.mname, r.rname, $r.serial, $r.refresh, $r.retry, $r.expire, $r.minimum].join(" ")
 
 method parse*(r: SOARecord, data: StringStream) =
   r.mname = data.getName()

--- a/src/dnsclientpkg/types.nim
+++ b/src/dnsclientpkg/types.nim
@@ -106,8 +106,8 @@ type
 
 
 
-method parse*(r: ResourceRecord, data: StringStream) {.base.} =
+method parse*(r: ResourceRecord, data: StringStream) {.base, raises: [Defect, OSError, IOError].} =
   raise newException(LibraryError, "parser for " & $r.kind & " is not implemented yet")
 
-method toString*(r: ResourceRecord): string {.base.} =
+method toString*(r: ResourceRecord): string {.base, raises: [Defect, OSError, IOError].} =
   raise newException(LibraryError, "to override!")


### PR DESCRIPTION
Nim methods can raise anything by default
This PR adds an explicit `raises` to `toString` & `parse` to list the allowed exceptions in them

`soa` also used [`%`](https://nim-lang.org/docs/strutils.html#%25%2Cstring%2CopenArray%5Bstring%5D) in the `toString`, which can raise a ValueError. A join, which can't fail, is now used instead