### PR TITLE
fix(txt): TXT can contain multiple strings

### DIFF
--- a/src/dnsclientpkg/records/txt.nim
+++ b/src/dnsclientpkg/records/txt.nim
@@ -1,9 +1,11 @@
 type TXTRecord* = ref object of ResourceRecord
-    length*: uint8
-    data*: string
+    strings*: seq[string]
 
-method toString*(r: TXTRecord): string = r.data
+method toString*(r: TXTRecord): string = r.strings.join()
 
 method parse*(r: TXTRecord, data: StringStream) =
-    r.length = data.readUint8()
-    r.data = data.readStr(r.length.int)
+    var bytesLeft = r.rdlength.int
+    while bytesLeft > 0:
+        let length = data.readUint8()
+        r.strings.add(data.readStr(length.int))
+        bytesLeft -= length.int + 1

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -25,7 +25,7 @@ test "query TXT":
   let resp = client.sendQuery("txt.example.huy.im", TXT)
   assert resp.answers[0].kind == TXT
   let rr = TXTRecord(resp.answers[0])
-  assert rr.data == "dnsclient.nim"
+  assert rr.strings == @["dnsclient.nim"]
 
 test "query MX":
   let resp = client.sendQuery("mx.example.huy.im", MX)


### PR DESCRIPTION
Adds support for multiple strings in a TXT record.

According to Section 6.1. of [RFC6763](https://www.ietf.org/rfc/rfc6763.txt):
> The format of the data within a DNS TXT record is one **or more** strings, packed together in memory without any intervening gaps or padding bytes for word alignment.

and

> The format of each constituent string within the DNS TXT record is a single length byte, followed by 0-255 bytes of text data.

This PR changes the `TXTRecord` type to consist of one or more strings and uses the `rdlength` field to iteratively parse strings from the rdata according to the RFC.

Since the `type` changed, the corresponding test had to be updated as well.